### PR TITLE
Ecma 418-2 2025 updates to N, T and R metrics

### DIFF
--- a/src/mlab/ECMA_418-2/Subfunctions/shmAuditoryFiltBank.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmAuditoryFiltBank.m
@@ -3,7 +3,7 @@ function signalFiltered = shmAuditoryFiltBank(signal, outPlot)
 %
 % Returns a set of signals, bandpass filtered for the inner ear response
 % in each half-Bark critical band rate scale width, according to
-% ECMA-418-2:2024 (the Sottek Hearing Model) for an input calibrated
+% ECMA-418-2:2025 (the Sottek Hearing Model) for an input calibrated
 % single (sound pressure) time-series signal.
 %
 % Inputs
@@ -38,7 +38,7 @@ function signalFiltered = shmAuditoryFiltBank(signal, outPlot)
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 27/09/2023
-% Date last modified: 26/05/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -65,14 +65,14 @@ function signalFiltered = shmAuditoryFiltBank(signal, outPlot)
 
 %% Define constants
 
-sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2024
-deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2024
-c = 0.1618;  % critical band centre-frequency demoninator constant defined in Section 5.1.4.1 ECMA-418-2:2024
+sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2025
+deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2025
+c = 0.1618;  % critical band centre-frequency demoninator constant defined in Section 5.1.4.1 ECMA-418-2:2025
 
 dz = 0.5;
 halfBark = 0.5:dz:26.5;  % half-overlapping critical band rate scale
-bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2024
-dfz = sqrt(deltaFreq0^2 + (c*bandCentreFreqs).^2);  % Section 5.1.4.1 Equation 10 ECMA-418-2:2024
+bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2025
+dfz = sqrt(deltaFreq0^2 + (c*bandCentreFreqs).^2);  % Section 5.1.4.1 Equation 10 ECMA-418-2:2025
 
 
 %% Signal processing
@@ -80,30 +80,30 @@ dfz = sqrt(deltaFreq0^2 + (c*bandCentreFreqs).^2);  % Section 5.1.4.1 Equation 1
 % Apply auditory filter bank
 % --------------------------
 % Filter equalised signal using 53 1/2Bark ERB filters according to 
-% Section 5.1.4.2 ECMA-418-2:2024
+% Section 5.1.4.2 ECMA-418-2:2025
 
-k = 5;  % filter order = 5, footnote 5 ECMA-418-2:2024
-e_i = [0, 1, 11, 11, 1];  % filter coefficients for Section 5.1.4.2 Equation 15 ECMA-418-2:2024
+k = 5;  % filter order = 5, footnote 5 ECMA-418-2:2025
+e_i = [0, 1, 11, 11, 1];  % filter coefficients for Section 5.1.4.2 Equation 15 ECMA-418-2:2025
 
 for zBand = 53:-1:1
-    % Section 5.1.4.1 Equation 8 ECMA-418-2:2024
+    % Section 5.1.4.1 Equation 8 ECMA-418-2:2025
     tau = (1/(2^(2*k - 1))).*nchoosek(2*k - 2, k - 1).*(1./dfz(zBand));
     
-    d = exp(-1./(sampleRate48k.*tau)); % Section 5.1.4.1 ECMA-418-2:2024
+    d = exp(-1./(sampleRate48k.*tau)); % Section 5.1.4.1 ECMA-418-2:2025
     
-    % Band-pass modifier Section 5.1.4.2 Equation 16/17 ECMA-418-2:2024
+    % Band-pass modifier Section 5.1.4.2 Equation 16/17 ECMA-418-2:2025
     bp = exp((1i.*2.*pi.*bandCentreFreqs(zBand).*(0:k+1))./sampleRate48k);
     
-    % Feed-backward coefficients, Section 5.1.4.2 Equation 14 ECMA-418-2:2024
+    % Feed-backward coefficients, Section 5.1.4.2 Equation 14 ECMA-418-2:2025
     m_a = 1:k;
     a_m = ([1, ((-d).^m_a).*arrayfun(@(m_) nchoosek(k, m_), m_a)]).*bp(1:k+1);
 
-    % Feed-forward coefficients, Section 5.1.4.2 Equation 15 ECMA-418-2:2024
+    % Feed-forward coefficients, Section 5.1.4.2 Equation 15 ECMA-418-2:2025
     m_b = 0:k-1;
     i = 1:k-1;
     b_m = ((((1-d).^k)./sum(e_i(i+1).*(d.^i))).*(d.^m_b).*e_i).*bp(1:k);
 
-    % Recursive filter Section 5.1.4.2 Equation 13 ECMA-418-2:2024
+    % Recursive filter Section 5.1.4.2 Equation 13 ECMA-418-2:2025
     % Note, the results are complex so 2x the real-valued band-pass signal
     % is required.
     signalFiltered(:, zBand, :) = 2*real(filter(b_m, a_m, signal));

--- a/src/mlab/ECMA_418-2/Subfunctions/shmBasisLoudness.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmBasisLoudness.m
@@ -2,7 +2,7 @@ function [signalRectSeg, basisLoudness, blockRMS] = shmBasisLoudness(signalSegme
 % [signalRectSeg, basisLoudness, blockRMS] = shmBandBasisLoudness(signalSegmented, bandCentreFreq)
 %
 % Returns rectified input and basis loudness in specified half-Bark
-% critical band according to ECMA-418-2:2024 (the Sottek Hearing Model)
+% critical band according to ECMA-418-2:2025 (the Sottek Hearing Model)
 % for an input band-limited signal, segmented into processing blocks
 %
 % Inputs
@@ -43,7 +43,7 @@ function [signalRectSeg, basisLoudness, blockRMS] = shmBasisLoudness(signalSegme
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 27/09/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -82,22 +82,22 @@ end
 
 %% Define constants
 
-deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2024
-c = 0.1618;  % Half-Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2024
+deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2025
+c = 0.1618;  % Half-Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2025
 
 halfBark = 0.5:0.5:26.5;  % half-critical band rate scale
-bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2024
+bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2025
 
-cal_N = 0.0211668;  % Calibration factor from Section 5.1.8 Equation 23 ECMA-418-2:2024
-cal_Nx = 1.00132;  % Calibration multiplier (Footnote 8 ECMA-418-2:2024)
+cal_N = 0.0211668;  % Calibration factor from Section 5.1.8 Equation 23 ECMA-418-2:2025
+cal_Nx = 1.00132;  % Calibration multiplier (Footnote 8 ECMA-418-2:2025)
 
-a = 1.5;  % Constant (alpha) from Section 5.1.8 Equation 23 ECMA-418-2:2024
+a = 1.5;  % Constant (alpha) from Section 5.1.8 Equation 23 ECMA-418-2:2025
 
-% Values from Section 5.1.8 Table 2 ECMA-418-2:2024
+% Values from Section 5.1.8 Table 2 ECMA-418-2:2025
 p_threshold = 2e-5*10.^((15:10:85)/20).';
 v = [1, 0.6602, 0.0864, 0.6384, 0.0328, 0.4068, 0.2082, 0.3994, 0.6434];
 
-% Loudness threshold in quiet Section 5.1.9 Table 3 ECMA-418-2:2024
+% Loudness threshold in quiet Section 5.1.9 Table 3 ECMA-418-2:2025
 LTQz = [0.3310, 0.1625, 0.1051, 0.0757, 0.0576, 0.0453, 0.0365, 0.0298,...
         0.0247, 0.0207, 0.0176, 0.0151, 0.0131, 0.0115, 0.0103, 0.0093,...
         0.0086, 0.0081, 0.0077, 0.0074, 0.0073, 0.0072, 0.0071, 0.0072,...
@@ -109,7 +109,7 @@ LTQz = [0.3310, 0.1625, 0.1051, 0.0757, 0.0576, 0.0453, 0.0365, 0.0298,...
 %% Input check
 
 if ~isempty(bandCentreFreq) && ~ismember(bandCentreFreq, bandCentreFreqs)
-    error("Input half-Bark critical rate scale band centre frequency does not match ECMA-418-2:2024 values")
+    error("Input half-Bark critical rate scale band centre frequency does not match ECMA-418-2:2025 values")
 end
 
 %% Signal processing
@@ -122,19 +122,19 @@ signalRectSeg(signalSegmented <= 0) = 0;
 
 % Calculation of RMS
 % ------------------
-% Section 5.1.7 Equation 22 ECMA-418-2:2024
+% Section 5.1.7 Equation 22 ECMA-418-2:2025
 blockRMS = sqrt((2/size(signalRectSeg, 1))*sum(signalRectSeg.^2, 1));
 
 % Transformation into Loudness
 % ----------------------------
-% Section 5.1.8 Equations 23 & 24 ECMA-418-2:2024
+% Section 5.1.8 Equations 23 & 24 ECMA-418-2:2025
 bandLoudness = cal_N*cal_Nx*(blockRMS/20e-6).*prod((1 + (blockRMS./p_threshold).^a).^((diff(v)/a)'));
 
 % remove singleton dimension from outputs
 blockRMS = squeeze(blockRMS);
 bandLoudness = squeeze(bandLoudness);
 
-% Section 5.1.9 Equation 25 ECMA-418-2:2024
+% Section 5.1.9 Equation 25 ECMA-418-2:2025
 if ~isempty(bandCentreFreq) && length(size(signalSegmented)) == 2
     % half-Bark critical band basis loudness
     basisLoudness = bandLoudness - LTQz(bandCentreFreq == bandCentreFreqs);

--- a/src/mlab/ECMA_418-2/Subfunctions/shmNoiseRedLowPass.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmNoiseRedLowPass.m
@@ -2,7 +2,7 @@ function signalFiltered = shmNoiseRedLowPass(signal, sampleRateIn)
 % signalFiltered = shmNoiseRedLowPass(signal, sampleRateIn)
 %
 % Returns signal low pass filtered for noise reduction according to
-% ECMA-418-2:2024 (the Sottek Hearing Model) for an input signal.
+% ECMA-418-2:2025 (the Sottek Hearing Model) for an input signal.
 %
 % Inputs
 % ------
@@ -34,7 +34,7 @@ function signalFiltered = shmNoiseRedLowPass(signal, sampleRateIn)
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 22/09/2023
-% Date last modified: 27/05/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -59,24 +59,24 @@ function signalFiltered = shmNoiseRedLowPass(signal, sampleRateIn)
         sampleRateIn (1, 1) double {mustBePositive}
     end
 
-k = 3; % Footnote 21 ECMA-418-2:2024
-e_i = [0, 1, 1]; % Footnote 21 ECMA-418-2:2024
+k = 3; % Footnote 21 ECMA-418-2:2025
+e_i = [0, 1, 1]; % Footnote 21 ECMA-418-2:2025
 
-% Footnote 20 ECMA-418-2:2024
+% Footnote 20 ECMA-418-2:2025
 tau = 1/32*6/7;
 
-d = exp(-1/(sampleRateIn*tau)); % Section 5.1.4.2 ECMA-418-2:2024
+d = exp(-1/(sampleRateIn*tau)); % Section 5.1.4.2 ECMA-418-2:2025
 
-% Feed-backward coefficients, Equation 14 ECMA-418-2:2024
+% Feed-backward coefficients, Equation 14 ECMA-418-2:2025
 m_a = 1:k;
 a = [1, ((-d).^m_a).*arrayfun(@(m_) nchoosek(k, m_), m_a)];
 
-% Feed-forward coefficients, Equation 15 ECMA-418-2:2024
+% Feed-forward coefficients, Equation 15 ECMA-418-2:2025
 m_b = 0:k-1;
 i = 1:k-1;
 b = (((1 - d)^k)./sum(e_i(i + 1).*(d.^i))).*(d.^m_b).*e_i;
 
-% Recursive filter Equation 13 ECMA-418-2:2024
+% Recursive filter Equation 13 ECMA-418-2:2025
 signalFiltered = filter(b, a, signal);
 
 end

--- a/src/mlab/ECMA_418-2/Subfunctions/shmOutMidEarFilter.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmOutMidEarFilter.m
@@ -2,7 +2,7 @@ function signalFiltered  = shmOutMidEarFilter(signal, soundField, outPlot)
 % signalFiltered  = shmOutMidEarFilter(signal, soundField, outPlot)
 %
 % Returns signal filtered for outer and middle ear response according to
-% ECMA-418-2:2024 (the Hearing Model of Sottek) for an input calibrated
+% ECMA-418-2:2025 (the Hearing Model of Sottek) for an input calibrated
 % audio (sound pressure) time-series signal. Optional plot output shows
 % frequency and phase response of the filter.
 %
@@ -46,7 +46,7 @@ function signalFiltered  = shmOutMidEarFilter(signal, soundField, outPlot)
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 26/09/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -85,7 +85,7 @@ else
     % Apply outer & middle ear filter bank
     % ------------------------------------
     %
-    % Filter coefficients from Section 5.1.3.2 Table 1 ECMA-418-2:2024
+    % Filter coefficients from Section 5.1.3.2 Table 1 ECMA-418-2:2025
     % b_0k = [1.015896, 0.958943, 0.961372, 2.225804, 0.471735, 0.115267, 0.988029,...
     %         1.952238];
     % b_1k = [-1.925299, -1.806088, -1.763632, -1.43465, -0.366092, 0.0, -1.912434,...
@@ -128,7 +128,7 @@ else
                a_0k(6:end).', a_1k(6:end).', a_2k(6:end).'];
     end
     
-    % Section 5.1.3.2 ECMA-418-2:2024 Outer and middle/inner ear signal filtering
+    % Section 5.1.3.2 ECMA-418-2:2025 Outer and middle/inner ear signal filtering
     signalFiltered = sosfilt(sos, signal, 1);
     
     %% Plot figures

--- a/src/mlab/ECMA_418-2/Subfunctions/shmPreProc.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmPreProc.m
@@ -2,7 +2,7 @@ function signalOut = shmPreProc(signal, blockSize, hopSize, padStart, padEnd)
 % signalFadePad = shmPreProc(signal, blockSize, hopSize, padStart, padEnd))
 %
 % Returns signal with fade-in and zero-padding pre-processing according to
-% ECMA-418-2:2024 (the Sottek Hearing Model) for an input signal.
+% ECMA-418-2:2025 (the Sottek Hearing Model) for an input signal.
 %
 % Inputs
 % ------
@@ -43,7 +43,7 @@ function signalOut = shmPreProc(signal, blockSize, hopSize, padStart, padEnd)
 % Institution: University of Salford
 %
 % Date created: 26/09/2023
-% Date last modified: 14/05/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -73,13 +73,13 @@ function signalOut = shmPreProc(signal, blockSize, hopSize, padStart, padEnd)
 % Input pre-processing
 % --------------------
 %
-% Fade in weighting function Section 5.1.2 ECMA-418-2:2024
+% Fade in weighting function Section 5.1.2 ECMA-418-2:2025
 fadeWeight = repmat(transpose(0.5 - 0.5*cos(pi*(0:239)/240)), 1, size(signal, 2));
 % Apply fade in
 signalFade = [fadeWeight.*signal(1:240, :);
               signal(241:end, :)];
 
-% Zero-padding Section 5.1.2 ECMA-418-2:2024
+% Zero-padding Section 5.1.2 ECMA-418-2:2025
 if padStart
     n_zeross = blockSize;  % start zero-padding
 else

--- a/src/mlab/ECMA_418-2/Subfunctions/shmResample.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmResample.m
@@ -1,7 +1,7 @@
 function [resampledSignal, resampledRate] = shmResample(signal, sampleRateIn)
 % [resampledSignal, resampledRate] = shmResample_(signal, sampleRateIn)
 %
-% Returns signal resampled to 48 kHz, according to ECMA-418-2:2024
+% Returns signal resampled to 48 kHz, according to ECMA-418-2:2025
 % (the Sottek Hearing Model) for an input signal.
 %
 % Inputs
@@ -37,7 +37,7 @@ function [resampledSignal, resampledRate] = shmResample(signal, sampleRateIn)
 % Institution: University of Salford
 %
 % Date created: 26/09/2023
-% Date last modified: 14/05/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -60,7 +60,7 @@ function [resampledSignal, resampledRate] = shmResample(signal, sampleRateIn)
 
 %% Define constants
 
-% Section 5.1.1 ECMA-418-2:2024
+% Section 5.1.1 ECMA-418-2:2025
 resampledRate = 48e3;  % Signal sample rate prescribed to be 48 kHz
 
 %% Signal processing

--- a/src/mlab/ECMA_418-2/Subfunctions/shmRoughLowPass.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmRoughLowPass.m
@@ -2,7 +2,7 @@ function specRoughness = shmRoughLowPass(specRoughEstTform, sampleRate, riseTime
 % specRoughness = shmRoughLowPass(specRoughEstTform, sampleRate, riseTime, fallTime)
 %
 % Returns specific roughness low pass filtered for smoothing according to
-% ECMA-418-2:2024 (the Sottek Hearing Model) for an input transformed
+% ECMA-418-2:2025 (the Sottek Hearing Model) for an input transformed
 % estimate of the specific roughnesss.
 %
 % Inputs
@@ -37,7 +37,7 @@ function specRoughness = shmRoughLowPass(specRoughEstTform, sampleRate, riseTime
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 22/09/2023
-% Date last modified: 29/05/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within

--- a/src/mlab/ECMA_418-2/Subfunctions/shmRoughWeight.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmRoughWeight.m
@@ -2,7 +2,7 @@ function roughWeight = shmRoughWeight(modRate, modfreqMaxWeight, roughWeightPara
 % roughWeight = shmRoughWeight(modRate, modfreqMaxWeight, roughWeightParams)
 %
 % Returns roughness weighting for high- and low-frequency (modulation
-% rates) according to ECMA-418-2:2024 (the Sottek Hearing Model) for a set
+% rates) according to ECMA-418-2:2025 (the Sottek Hearing Model) for a set
 % of modulation rates and parameters.
 %
 % Inputs
@@ -40,7 +40,7 @@ function roughWeight = shmRoughWeight(modRate, modfreqMaxWeight, roughWeightPara
 % Institution: University of Salford
 %
 % Date created: 10/07/2024
-% Date last modified: 29/05/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within

--- a/src/mlab/ECMA_418-2/Subfunctions/shmSignalSegment.m
+++ b/src/mlab/ECMA_418-2/Subfunctions/shmSignalSegment.m
@@ -2,7 +2,8 @@ function [signalSegmented, iBlocksOut] = shmSignalSegment(signal, axisN, blockSi
 % [signalSegmented, iBlocksOut] = shmSignalSegment(signal, axisN, blockSize,
 %                                                  overlap, i_start, endShrink)
 %
-% Returns input signal segmented into blocks for processing.
+% Returns input signal segmented into blocks for processing according to
+% ECMA-418-2:2025 (the Sottek Hearing Model).
 %
 % Inputs
 % ------
@@ -57,7 +58,7 @@ function [signalSegmented, iBlocksOut] = shmSignalSegment(signal, axisN, blockSi
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 27/09/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within

--- a/src/mlab/ECMA_418-2/acousticSHMLoudness.m
+++ b/src/mlab/ECMA_418-2/acousticSHMLoudness.m
@@ -2,7 +2,7 @@ function loudnessSHM = acousticSHMLoudness(p, sampleRateIn, axisN, soundField, w
 % loudnessSHM = acousticSHMLoudness(p, sampleRateIn, axisN, soundField,
 %                                   outPlot, binaural)
 %
-% Returns loudness values according to ECMA-418-2:2024 (using the Sottek
+% Returns loudness values according to ECMA-418-2:2025 (using the Sottek
 % Hearing Model) for an input calibrated single mono or single stereo
 % audio (sound pressure) time-series signal, p. For stereo signals, the
 % binaural loudness can be calculated, and each channel is also analysed
@@ -112,7 +112,7 @@ function loudnessSHM = acousticSHMLoudness(p, sampleRateIn, axisN, soundField, w
 % Institution: University of Salford
 %
 % Date created: 22/09/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -177,22 +177,22 @@ end
 
 %% Define constants
 
-sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2024 [r_s]
-deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2024 [deltaf(f=0)]
-c = 0.1618;  % Half-overlapping Bark band centre-frequency demoninator constant defined in Section 5.1.4.1 ECMA-418-2:2024
+sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2025 [r_s]
+deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2025 [deltaf(f=0)]
+c = 0.1618;  % Half-overlapping Bark band centre-frequency demoninator constant defined in Section 5.1.4.1 ECMA-418-2:2025
 
 dz = 0.5;  % critical band overlap [deltaz]
 halfBark = 0.5:dz:26.5;  % half-overlapping critical band rate scale [z]
-bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2024 [F(z)]
+bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2025 [F(z)]
 
-% Section 8.1.1 ECMA-418-2:2024
-weight_n = 0.5331;  % Equations 113 & 114 ECMA-418-2:2024 [w_n]
-% Table 12 ECMA-418-2:2024
+% Section 8.1.1 ECMA-418-2:2025
+weight_n = 0.5331;  % Equations 113 & 114 ECMA-418-2:2025 [w_n]
+% Table 12 ECMA-418-2:2025
 a = 0.2918;
 b = 0.5459;
 
 % Output sample rate based on tonality hop sizes (Section 6.2.6
-% ECMA-418-2:2024) [r_sd]
+% ECMA-418-2:2025) [r_sd]
 sampleRate1875 = sampleRate48k/256;
 
 %% Signal processing
@@ -208,30 +208,30 @@ end
 % Calculate specific loudnesses for tonal and noise components
 % ------------------------------------------------------------
 
-% Obtain tonal and noise component specific loudnesses from Sections 5 & 6 ECMA-418-2:2024
+% Obtain tonal and noise component specific loudnesses from Sections 5 & 6 ECMA-418-2:2025
 tonalitySHM = acousticSHMTonality(p_re, sampleRate48k, 1, soundField, waitBar,...
                                   false);
 
 specTonalLoudness = tonalitySHM.specTonalLoudness;  % [N'_tonal(l,z)]
 specNoiseLoudness = tonalitySHM.specNoiseLoudness;  % [N'_noise(l,z)]
 
-% Section 8.1.1 ECMA-418-2:2024
+% Section 8.1.1 ECMA-418-2:2025
 % Weight and combine component specific loudnesses
 for chan = chansIn:-1:1
 
-    % Equation 114 ECMA-418-2:2024 [e(z)]
+    % Equation 114 ECMA-418-2:2025 [e(z)]
     maxLoudnessFuncel = a./(max(specTonalLoudness(:, :, chan)...
                                 + specNoiseLoudness(:, :, chan), [],...
                                 2, "omitnan") + 1e-12) + b;
 
-    % Equation 113 ECMA-418-2:2024 [N'(l,z)]
+    % Equation 113 ECMA-418-2:2025 [N'(l,z)]
     specLoudness(:, :, chan) = (specTonalLoudness(:, :, chan).^maxLoudnessFuncel...
                                 + abs((weight_n.*specNoiseLoudness(:, :, chan)).^maxLoudnessFuncel)).^(1./maxLoudnessFuncel);
 end
 
 if chansIn == 2 && binaural
     % Binaural loudness
-    % Section 8.1.5 ECMA-418-2:2024 Equation 118 [N'_B(l,z)]
+    % Section 8.1.5 ECMA-418-2:2025 Equation 118 [N'_B(l,z)]
     specLoudness(:, :, 3) = sqrt(sum(specLoudness.^2, 3)/2);
     specTonalLoudness(:, :, 3) = sqrt(sum(specTonalLoudness.^2, 3)/2);
     specNoiseLoudness(:, :, 3) = sqrt(sum(specNoiseLoudness.^2, 3)/2);
@@ -242,11 +242,11 @@ else
     chansOut = chansIn;  % assign number of output channels
 end
 
-% Section 8.1.2 ECMA-418-2:2024
+% Section 8.1.2 ECMA-418-2:2025
 % Time-averaged specific loudness Equation 115 [N'(z)]
 specLoudnessPowAvg = (sum(specLoudness((57 + 1):end, :, :).^(1/log10(2)), 1)./size(specLoudness((57 + 1):end, :, :), 1)).^log10(2);
 
-% Section 8.1.3 ECMA-418-2:2024
+% Section 8.1.3 ECMA-418-2:2025
 % Time-dependent loudness Equation 116 [N(l)]
 % Discard singleton dimensions
 if chansOut == 1
@@ -257,7 +257,7 @@ else
     specLoudnessPowAvg = squeeze(specLoudnessPowAvg);
 end
 
-% Section 8.1.4 ECMA-418-2:2024
+% Section 8.1.4 ECMA-418-2:2025
 % Overall loudness Equation 117 [N]
 loudnessPowAvg = (sum(loudnessTDep((57 + 1):end, :).^(1/log10(2)), 1)./size(loudnessTDep((57 + 1):end, :), 1)).^log10(2);
 

--- a/src/mlab/ECMA_418-2/acousticSHMLoudnessFromComponent.m
+++ b/src/mlab/ECMA_418-2/acousticSHMLoudnessFromComponent.m
@@ -3,7 +3,7 @@ function loudnessSHM = acousticSHMLoudnessFromComponent(specTonalLoudness, specN
 %                                                specNoiseLoudness,
 %                                                outPlot, binaural)
 %
-% Returns loudness values according to ECMA-418-2:2024 (using the Sottek
+% Returns loudness values according to ECMA-418-2:2025 (using the Sottek
 % Hearing Model) for input component specific tonal loudness and specific
 % noise loudness, obtained using acousticSHMTonality.m. This is faster
 % than calculating via acousticSHMLoudness.m (which calls
@@ -78,7 +78,7 @@ function loudnessSHM = acousticSHMLoudnessFromComponent(specTonalLoudness, specN
 %
 % Assumptions
 % -----------
-% The input matrices are ECMA-418-2:2024 specific tonal and specific noise
+% The input matrices are ECMA-418-2:2025 specific tonal and specific noise
 % loudness, with dimensions orientated as [half-Bark bands, time blocks,
 % signal channels]
 %
@@ -92,7 +92,7 @@ function loudnessSHM = acousticSHMLoudnessFromComponent(specTonalLoudness, specN
 % Institution: University of Salford
 %
 % Date created: 22/08/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -145,41 +145,41 @@ end
 
 %% Define constants
 
-sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz, Section 5.1.1 ECMA-418-2:2024 [r_s]
-deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2024 [deltaf(f=0)]
-c = 0.1618;  % Half-overlapping Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2024
+sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz, Section 5.1.1 ECMA-418-2:2025 [r_s]
+deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2025 [deltaf(f=0)]
+c = 0.1618;  % Half-overlapping Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2025
 
 dz = 0.5;  % critical band resolution [deltaz]
 halfBark = dz:dz:26.5;  % half-overlapping critical band rate scale [z]
-bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2024 [F(z)]
+bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2025 [F(z)]
 
-% Section 8.1.1 ECMA-418-2:2024
-weight_n = 0.5331;  % Equations 113 & 114 ECMA-418-2:2024 [w_n]
-% Table 12 ECMA-418-2:2024
+% Section 8.1.1 ECMA-418-2:2025
+weight_n = 0.5331;  % Equations 113 & 114 ECMA-418-2:2025 [w_n]
+% Table 12 ECMA-418-2:2025
 a = 0.2918;
 b = 0.5459;
 
 % Output sample rate based on tonality hop sizes (Section 6.2.6
-% ECMA-418-2:2024) [r_sd]
+% ECMA-418-2:2025) [r_sd]
 sampleRate1875 = sampleRate48k/256;
 
 %% Signal processing
 
-% Section 8.1.1 ECMA-418-2:2024
+% Section 8.1.1 ECMA-418-2:2025
 % Weight and combine component specific loudnesses
 for chan = chansIn:-1:1
-    % Equation 114 ECMA-418-2:2024 [e(z)]
+    % Equation 114 ECMA-418-2:2025 [e(z)]
     maxLoudnessFuncel = a./(max(specTonalLoudness(:, :, chan)...
                                 + specNoiseLoudness(:, :, chan), [],...
                                 2, "omitnan") + 1e-12) + b;
-    % Equation 113 ECMA-418-2:2024 [N'(l,z)]
+    % Equation 113 ECMA-418-2:2025 [N'(l,z)]
     specLoudness(:, :, chan) = (specTonalLoudness(:, :, chan).^maxLoudnessFuncel...
                                     + abs((weight_n.*specNoiseLoudness(:, :, chan)).^maxLoudnessFuncel)).^(1./maxLoudnessFuncel);
 end
 
 if chansIn == 2 && binaural
     % Binaural loudness
-    % Section 8.1.5 ECMA-418-2:2024 Equation 118 [N'_B(l,z)]
+    % Section 8.1.5 ECMA-418-2:2025 Equation 118 [N'_B(l,z)]
     specLoudness(:, :, 3) = sqrt(sum(specLoudness.^2, 3)/2);
     specTonalLoudness(:, :, 3) = sqrt(sum(specTonalLoudness.^2, 3)/2);
     specNoiseLoudness(:, :, 3) = sqrt(sum(specNoiseLoudness.^2, 3)/2);
@@ -190,11 +190,11 @@ else
     chansOut = chansIn;  % assign number of output channels
 end
 
-% Section 8.1.2 ECMA-418-2:2024
+% Section 8.1.2 ECMA-418-2:2025
 % Time-averaged specific loudness Equation 115 [N'(z)]
 specLoudnessPowAvg = (sum(specLoudness((57 + 1):end, :, :).^(1/log10(2)), 1)./size(specLoudness((57 + 1):end, :, :), 1)).^log10(2);
 
-% Section 8.1.3 ECMA-418-2:2024
+% Section 8.1.3 ECMA-418-2:2025
 % Time-dependent loudness Equation 116 [N(l)]
 % Discard singleton dimensions
 if chansOut == 1
@@ -205,7 +205,7 @@ else
     specLoudnessPowAvg = squeeze(specLoudnessPowAvg);
 end
 
-% Section 8.1.4 ECMA-418-2:2024
+% Section 8.1.4 ECMA-418-2:2025
 % Overall loudness Equation 117 [N]
 loudnessPowAvg = (sum(loudnessTDep((57 + 1):end, :).^(1/log10(2)), 1)./size(loudnessTDep((57 + 1):end, :), 1)).^log10(2);
 

--- a/src/mlab/ECMA_418-2/acousticSHMRoughness.m
+++ b/src/mlab/ECMA_418-2/acousticSHMRoughness.m
@@ -1,7 +1,7 @@
 function roughnessSHM = acousticSHMRoughness(p, sampleRateIn, axisN, soundField, waitBar, outPlot, binaural)
 % roughnessSHM = acousticSHMRoughness(p, sampleRateIn, axisN, soundField, waitBar, outPlot, binaural)
 %
-% Returns roughness values according to ECMA-418-2:2024 (using the Sottek
+% Returns roughness values according to ECMA-418-2:2025 (using the Sottek
 % Hearing Model) for an input calibrated single mono or single stereo audio
 % (sound pressure) time-series signal, p. For stereo signals, the binaural
 % roughness can be calculated, and each channel is also analysed separately.
@@ -102,7 +102,7 @@ function roughnessSHM = acousticSHMRoughness(p, sampleRateIn, axisN, soundField,
 % Institution: University of Salford
 %
 % Date created: 12/10/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -168,21 +168,21 @@ end
 %% Define constants
 
 signalT = size(p, 1)/sampleRateIn;  % duration of input signal
-sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2024 [r_s]
-deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2024 [deltaf(f=0)]
-c = 0.1618;  % Half-overlapping Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2024 [c]
+sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2025 [r_s]
+deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2025 [deltaf(f=0)]
+c = 0.1618;  % Half-overlapping Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2025 [c]
 
 dz = 0.5;  % critical band overlap [deltaz]
 halfBark = 0.5:dz:26.5;  % half-overlapping critical band rate scale [z]
 nBands = length(halfBark);  % number of bands
-bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2024 [F(z)]
+bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2025 [F(z)]
 
-% Block and hop sizes Section 7.1.1 ECMA-418-2:2024
+% Block and hop sizes Section 7.1.1 ECMA-418-2:2025
 overlap = 0.75;  % block overlap proportion
 blockSize = 16384;  % block size [s_b]
 hopSize = (1 - overlap)*blockSize;  % hop size [s_h]
 
-% Downsampled block and hop sizes Section 7.1.2 ECMA-418-2:2024
+% Downsampled block and hop sizes Section 7.1.2 ECMA-418-2:2025
 downSample = 32;  % downsampling factor
 sampleRate1500 = sampleRate48k/downSample;
 blockSize1500 = blockSize/downSample;
@@ -190,49 +190,49 @@ blockSize1500 = blockSize/downSample;
 resDFT1500 = sampleRate1500/blockSize1500;  % DFT resolution (section 7.1.5.1) [deltaf]
 
 % Modulation rate error correction values Table 8, Section 7.1.5.1
-% ECMA-418-2:2024 [E(theta)]
+% ECMA-418-2:2025 [E(theta)]
 errorCorrection = [0.0000, 0.0457, 0.0907, 0.1346, 0.1765, 0.2157, 0.2515,...
                    0.2828, 0.3084, 0.3269, 0.3364, 0.3348, 0.3188, 0.2844,...
                    0.2259, 0.1351, 0.0000];
 errorCorrection = [errorCorrection, flip(-errorCorrection(1:end-1)), 0];
 
 % High modulation rate roughness perceptual scaling function
-% (section 7.1.5.2 ECMA-418-2:2024)
-% Table 11 ECMA-418-2:2024 [r_1; r_2]
+% (section 7.1.5.2 ECMA-418-2:2025)
+% Table 11 ECMA-418-2:2025 [r_1; r_2]
 roughScaleParams = [0.3560, 0.8024;
                     0.8049, 0.9333];
 roughScaleParams = [roughScaleParams(:, 1).*ones([2, sum(bandCentreFreqs < 1e3)]),...
                     roughScaleParams(:, 2).*ones([2, sum(bandCentreFreqs >= 1e3)])];
-% Equation 84 ECMA-418-2:2024 [r_max(z)]
+% Equation 84 ECMA-418-2:2025 [r_max(z)]
 roughScale = 1./(1 + roughScaleParams(1, :).*abs(log2(bandCentreFreqs/1000)).^roughScaleParams(2, :));
 roughScale = reshape(roughScale, [1, 1, nBands]);  % Note: this is to ease parallelised calculations
 
 % High/low modulation rate roughness perceptual weighting function parameters
-% (section 7.1.5.2 ECMA-418-2:2024)
-% Equation 86 ECMA-418-2:2024 [f_max(z)]
+% (section 7.1.5.2 ECMA-418-2:2025)
+% Equation 86 ECMA-418-2:2025 [f_max(z)]
 modfreqMaxWeight = 72.6937*(1 - 1.1739*exp(-5.4583*bandCentreFreqs/1000));
 
 % TODO for next update
 %bandCentreFreqsWeight = max(ones(size(bandCentreFreqs)).*bandCentreFreqs(3), bandCentreFreqs);
 %modfreqMaxWeight = 72.6937*(1 - 1.1739*exp(-5.4583*bandCentreFreqsWeight/1000));
 
-% Equation 87 ECMA-418-2:2024 [q_1; q_2(z)]
+% Equation 87 ECMA-418-2:2025 [q_1; q_2(z)]
 roughHiWeightParams = [1.2822*ones(size(bandCentreFreqs));...
                        0.2471*ones(size(bandCentreFreqs))];
 mask = bandCentreFreqs/1000 >= 2^-3.4253;
 roughHiWeightParams(2, mask) = 0.2471 + 0.0129.*(log2(bandCentreFreqs(mask)/1000) + 3.4253).^2;
 roughHiWeightParams = reshape(roughHiWeightParams, [2, 1, nBands]);  % Note: this is to ease parallelised calculations
 
-% (section 7.1.5.4 ECMA-418-2:2024)
-% Equation 96 ECMA-418-2:2024 [q_1; q_2(z)]
+% (section 7.1.5.4 ECMA-418-2:2025)
+% Equation 96 ECMA-418-2:2025 [q_1; q_2(z)]
 roughLoWeightParams = [0.7066*ones(size(bandCentreFreqs));...
                        1.0967 - 0.064.*log2(bandCentreFreqs/1000)];
 
-% Output sample rate (section 7.1.7 ECMA-418-2:2024) [r_s50]
+% Output sample rate (section 7.1.7 ECMA-418-2:2025) [r_s50]
 sampleRate50 = 50;
 
 % Calibration constant
-cal_R = 0.0180909;   % calibration factor in Section 7.1.7 Equation 104 ECMA-418-2:2024 [c_R]
+cal_R = 0.0180909;   % calibration factor in Section 7.1.7 Equation 104 ECMA-418-2:2025 [c_R]
 %cal_Rx = 1/1.00123972659601;  % calibration adjustment factor
 %cal_R*cal_Rx = 0.0180685; adjusted calibration value
 cal_Rx = 1/1.0011565;  % calibration adjustment factor
@@ -250,14 +250,14 @@ end
 % Input signal samples
 n_samples = size(p_re, 1);
 
-% Section 5.1.2 ECMA-418-2:2024 Fade in weighting and zero-padding
+% Section 5.1.2 ECMA-418-2:2025 Fade in weighting and zero-padding
 % (only the start is zero-padded)
 pn = shmPreProc(p_re, blockSize, hopSize, true, false);
 
 % Apply outer & middle ear filter
 % -------------------------------
 %
-% Section 5.1.3.2 ECMA-418-2:2024 Outer and middle/inner ear signal filtering
+% Section 5.1.3.2 ECMA-418-2:2025 Outer and middle/inner ear signal filtering
 pn_om = shmOutMidEarFilter(pn, soundField);
 
 n_steps = 270;  % approximate number of calculation steps
@@ -278,7 +278,7 @@ for chan = chansIn:-1:1
     end % end of if branch for waitBar
 
     % Filter equalised signal using 53 1/2-overlapping Bark filters
-    % according to Section 5.1.4.2 ECMA-418-2:2024
+    % according to Section 5.1.4.2 ECMA-418-2:2025
     pn_omz = shmAuditoryFiltBank(pn_om(:, chan), false);
 
     % Note: At this stage, typical computer RAM limits impose a need to loop
@@ -293,7 +293,7 @@ for chan = chansIn:-1:1
             i_step = i_step + 1;
         end % end of if branch for waitBar
 
-        % Section 5.1.5 ECMA-418-2:2024
+        % Section 5.1.5 ECMA-418-2:2025
         i_start = 1;
         [pn_lz, iBlocksOut] = shmSignalSegment(pn_omz(:, zBand), 1,...
                                                blockSize, overlap,...
@@ -304,7 +304,7 @@ for chan = chansIn:-1:1
         if waitBar
             i_step = i_step + 1;
         end
-        % Sections 5.1.6 to 5.1.9 ECMA-418-2:2024
+        % Sections 5.1.6 to 5.1.9 ECMA-418-2:2025
         [~, bandBasisLoudness, ~] = shmBasisLoudness(pn_lz, bandCentreFreqs(zBand));
         basisLoudness(:, :, zBand) = bandBasisLoudness;
     
@@ -313,7 +313,7 @@ for chan = chansIn:-1:1
         if waitBar
             i_step = i_step + 1;
         end
-        % Sections 7.1.2 ECMA-418-2:2024
+        % Sections 7.1.2 ECMA-418-2:2025
         % magnitude of Hilbert transform with downsample - Equation 65
         % [p(ntilde)_E,l,z]
         envelopes(:, :, zBand) = downsample(abs(hilbert(pn_lz)), downSample, 0);
@@ -322,7 +322,7 @@ for chan = chansIn:-1:1
 
     % Note: With downsampled envelope signals, parallelised approach can continue
 
-    % Section 7.1.3 equation 66 ECMA-418-2:2024 [Phi(k)_E,l,z]
+    % Section 7.1.3 equation 66 ECMA-418-2:2025 [Phi(k)_E,l,z]
     modSpectra = zeros(size(envelopes));
     envelopeWin = envelopes.*repmat(hann(blockSize1500, "periodic"), 1,...
                                     size(envelopes, 2), nBands)./sqrt(0.375);
@@ -339,18 +339,18 @@ for chan = chansIn:-1:1
 
     % Envelope noise reduction
     % ------------------------
-    % section 7.1.4 ECMA-418-2:2024
+    % section 7.1.4 ECMA-418-2:2025
     modSpectraAvg = modSpectra;
     modSpectraAvg(:, :, 2:end-1) = movmean(modSpectra, [1, 1], 3, 'Endpoints', 'discard');
     
     modSpectraAvgSum = sum(modSpectraAvg, 3);  % Equation 68 [s(l,k)]
 
-    % Equation 71 ECMA-418-2:2024 [wtilde(l,k)]
+    % Equation 71 ECMA-418-2:2025 [wtilde(l,k)]
     clipWeight = 0.0856.*modSpectraAvgSum(1:size(modSpectraAvg, 1)/2 + 1, :)...
                  ./(median(modSpectraAvgSum(3:size(modSpectraAvg, 1)/2, :), 1) + 1e-10)...
                  .*transpose(min(max(0.1891.*exp(0.012.*(0:size(modSpectraAvg, 1)/2)), 0), 1));
 
-    % Equation 70 ECMA-418-2:2024 [w(l,k)]
+    % Equation 70 ECMA-418-2:2025 [w(l,k)]
     weightingFactor1 = zeros(size(modSpectraAvgSum(1:257, :, :)));
     mask = clipWeight >= 0.05*max(clipWeight(3:256, :), [], 1);
     weightingFactor1(mask) = min(max(clipWeight(mask) - 0.1407, 0), 1);
@@ -362,7 +362,7 @@ for chan = chansIn:-1:1
 
     % Spectral weighting
     % ------------------
-    % Section 7.1.5 ECMA-418-2:2024
+    % Section 7.1.5 ECMA-418-2:2025
     % theta used in equation 79, including additional index for
     % errorCorrection terms from table 10
     theta = 0:1:33;
@@ -377,21 +377,21 @@ for chan = chansIn:-1:1
             i_step = i_step + 1;
         end % end of if branch for waitBar
 
-        % Section 7.1.5.1 ECMA-418-2:2024
+        % Section 7.1.5.1 ECMA-418-2:2025
         for lBlock = nBlocks:-1:1
             % identify peaks in each block (for each band)
-            % NOTE: here, the search starts from k=1 so that a peak at k=2
-            % can be detected
-            [PhiPks, kLocs, ~, proms] = findpeaks(modWeightSpectraAvg(1 + mlabIndex:256 + mlabIndex,...
+            startIdx = 2;
+            endIdx = 255;
+            [PhiPks, kLocs, ~, proms] = findpeaks(modWeightSpectraAvg(startIdx + mlabIndex:endIdx + mlabIndex,...
                                                                       lBlock,...
                                                                       zBand));
 
             % reindex kLocs to match spectral start index used in findpeaks
             % for indexing into modulation spectra matrices
-            kLocs = kLocs + mlabIndex;
+            kLocs = kLocs + startIdx;
 
-            % we cannot have a peak at k=1 or k=256
-            mask = and((kLocs ~= 1 + mlabIndex), (kLocs ~= 256 + mlabIndex));
+            % we cannot have peaks at k = 1, 2, 255 or 256
+            mask = ~ismember(kLocs, [startIdx, startIdx + 1, endIdx, endIdx + 1]);
             kLocs = kLocs(mask);
             PhiPks = PhiPks(mask);
 
@@ -417,7 +417,7 @@ for chan = chansIn:-1:1
                 kLocs = kLocs(mask);
                 % loop over peaks to obtain modulation rates
                 for iPeak = length(PhiPks):-1:1
-                    % Equation 74 ECMA-418-2:2024
+                    % Equation 74 ECMA-418-2:2025
                     % Note: here, the kLoc values are used as indices for
                     % the modulation spectral matrix, so MATLAB indexing
                     % is correctly addressed (see Equation 75 below)
@@ -429,7 +429,7 @@ for chan = chansIn:-1:1
                     % Equation 82 [A_i(l,z)]
                     modAmp(iPeak, lBlock, zBand) = sum(modAmpMat);
 
-                    % Equation 75 ECMA-418-2:2024
+                    % Equation 75 ECMA-418-2:2025
                     % Note: because the kLoc index values are used directly
                     % in the calculation, MATLAB indexing needs to be
                     % compensated for by subtracting 1 from kLocs
@@ -440,25 +440,25 @@ for chan = chansIn:-1:1
 
                     coeffVec = modIndexMat\modAmpMat;  % Equation 73 solution [C]
 
-                    % Equation 76 ECMA-418-2:2024 [ftilde_p,i(l,z)]
+                    % Equation 76 ECMA-418-2:2025 [ftilde_p,i(l,z)]
                     modRateEst = -(coeffVec(2)/(2*coeffVec(1)))*resDFT1500;
 
-                    % Equation 79 ECMA-418-2:2024 [beta(theta)]
+                    % Equation 79 ECMA-418-2:2025 [beta(theta)]
                     errorBeta = (floor(modRateEst/resDFT1500) + theta(1:33)/32)*resDFT1500...
                                 - (modRateEst + errorCorrection(theta(1:33) + mlabIndex)); % compensated theta value for MATLAB-indexing
 
-                    % Equation 80 ECMA-418-2:2024 [theta_min]
+                    % Equation 80 ECMA-418-2:2025 [theta_min]
                     [~, i_minError] = min(abs(errorBeta));
                     thetaMinError = theta(i_minError);  % the result here is 0-indexed
 
-                    % Equation 81 ECMA-418-2:2024 [theta_corr]
+                    % Equation 81 ECMA-418-2:2025 [theta_corr]
                     if thetaMinError > 0 && errorBeta(i_minError)*errorBeta(i_minError - 1) < 0 % (0-indexed)
                         thetaCorr = thetaMinError;  % 0-indexed
                     else
                         thetaCorr = thetaMinError + 1;  % 0-indexed
                     end  % end of eq 81 if-branch
 
-                    % Equation 78 ECMA-418-2:2024
+                    % Equation 78 ECMA-418-2:2025
                     % thetaCorr is 0-indexed so needs adjusting when
                     % indexing
                     % [rho(ftilde_p,i(l,z))]
@@ -469,7 +469,7 @@ for chan = chansIn:-1:1
                                     /(errorBeta(thetaCorr + mlabIndex)...
                                       - errorBeta(thetaCorr + mlabIndex - 1));
 
-                    % Equation 77 ECMA-418-2:2024 [f_p,i(l,z)]
+                    % Equation 77 ECMA-418-2:2025 [f_p,i(l,z)]
                     modRate(iPeak, lBlock, zBand) = modRateEst + biasAdjust;
 
                 end  % end of for loop over peaks in block per band
@@ -477,7 +477,7 @@ for chan = chansIn:-1:1
         end  % end of for loop over blocks for peak detection      
     end  % end of for loop over bands for modulation spectral weighting
 
-    % Section 7.1.5.2 ECMA-418-2:2024 - Weighting for high modulation rates
+    % Section 7.1.5.2 ECMA-418-2:2025 - Weighting for high modulation rates
     % Equation 85 [G_l,z,i(f_p,i(l,z))]
     roughHiWeight = shmRoughWeight(modRate,...
                                    reshape(modfreqMaxWeight, [1, 1, nBands]),...
@@ -491,7 +491,7 @@ for chan = chansIn:-1:1
     modAmpHiWeight(mask) = modAmpHiWeight(mask).*roughHiWeight(mask);
 
 
-    % Section 7.1.5.3 ECMA-418-2:2024 - Estimation of fundamental modulation rate
+    % Section 7.1.5.3 ECMA-418-2:2025 - Estimation of fundamental modulation rate
     % TODO: replace the loop approach with a parallelised approach!
     % matrix initialisation to ensure zero rates do not cause missing bands in output
     modFundRate = zeros([nBlocks, nBands]);
@@ -598,7 +598,7 @@ for chan = chansIn:-1:1
 
     % Time-dependent specific roughness
     % ---------------------------------
-    % Section 7.1.7 ECMA-418-2:2024
+    % Section 7.1.7 ECMA-418-2:2025
 
     % interpolation to 50 Hz sampling rate
     % Section 7.1.7 Equation 103 [l_50,end]
@@ -640,7 +640,7 @@ for chan = chansIn:-1:1
 end  % end of for loop over channels
 
 % Binaural roughness
-% Section 7.1.11 ECMA-418-2:2024 [R'_B(l_50,z)]
+% Section 7.1.11 ECMA-418-2:2025 [R'_B(l_50,z)]
 if chansIn == 2 && binaural
     specRoughness(:, :, 3) = sqrt(sum(specRoughness.^2, 3)/2);  % Equation 112
     chansOut = 3;  % set number of 'channels' to stereo plus single binaural
@@ -650,11 +650,11 @@ else
     chansOut = chansIn;  % assign number of output channels
 end
 
-% Section 7.1.8 ECMA-418-2:2024
+% Section 7.1.8 ECMA-418-2:2025
 % Time-averaged specific roughness [R'(z)]
 specRoughnessAvg = mean(specRoughness(17:end, :, :), 1);
 
-% Section 7.1.9 ECMA-418-2:2024
+% Section 7.1.9 ECMA-418-2:2025
 % Time-dependent roughness Equation 111 [R(l_50)]
 % Discard singleton dimensions
 if chansOut == 1
@@ -665,7 +665,7 @@ else
     specRoughnessAvg = squeeze(specRoughnessAvg);
 end
 
-% Section 7.1.10 ECMA-418-2:2024
+% Section 7.1.10 ECMA-418-2:2025
 % Overall roughness [R]
 roughness90Pc = prctile(roughnessTDep(17:end, :, :), 90, 1);
 

--- a/src/mlab/ECMA_418-2/acousticSHMRoughness.m
+++ b/src/mlab/ECMA_418-2/acousticSHMRoughness.m
@@ -391,7 +391,8 @@ for chan = chansIn:-1:1
             kLocs = kLocs + startIdx;
 
             % we cannot have peaks at k = 1, 2, 255 or 256
-            mask = ~ismember(kLocs, [startIdx, startIdx + 1, endIdx, endIdx + 1]);
+            mask = ~ismember(kLocs, [startIdx - 1, startIdx,...
+                                     endIdx, endIdx + 1]);
             kLocs = kLocs(mask);
             PhiPks = PhiPks(mask);
 

--- a/src/mlab/ECMA_418-2/acousticSHMTonality.m
+++ b/src/mlab/ECMA_418-2/acousticSHMTonality.m
@@ -1,7 +1,7 @@
 function tonalitySHM = acousticSHMTonality(p, sampleRateIn, axisN, soundField, waitBar, outPlot)
 % tonalitySHM = acousticSHMTonality(p, sampleRateIn, axisN, soundField, waitBar, outPlot)
 %
-% Returns tonality values and frequencies according to ECMA-418-2:2024
+% Returns tonality values and frequencies according to ECMA-418-2:2025
 % (using the Sottek Hearing Model) for an input calibrated single mono
 % or single stereo audio (sound pressure) time-series signal, p.
 %
@@ -124,7 +124,7 @@ function tonalitySHM = acousticSHMTonality(p, sampleRateIn, axisN, soundField, w
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 07/08/2023
-% Date last modified: 12/06/2025
+% Date last modified: 27/06/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -192,16 +192,16 @@ end
 
 %% Define constants
 
-sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2024 [r_s]
-deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2024 [deltaf(f=0)]
-c = 0.1618;  % Half-overlapping Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2024
+sampleRate48k = 48e3;  % Signal sample rate prescribed to be 48kHz (to be used for resampling), Section 5.1.1 ECMA-418-2:2025 [r_s]
+deltaFreq0 = 81.9289;  % defined in Section 5.1.4.1 ECMA-418-2:2025 [deltaf(f=0)]
+c = 0.1618;  % Half-overlapping Bark band centre-frequency denominator constant defined in Section 5.1.4.1 ECMA-418-2:2025
 
 dz = 0.5;  % critical band overlap [deltaz]
 halfBark = 0.5:dz:26.5;  % half-overlapping critical band rate scale [z]
-bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2024 [F(z)]
-dfz = sqrt(deltaFreq0^2 + (c*bandCentreFreqs).^2);  % Section 5.1.4.1 Equation 10 ECMA-418-2:2024 [deltaf(z)]
+bandCentreFreqs = (deltaFreq0/c)*sinh(c*halfBark);  % Section 5.1.4.1 Equation 9 ECMA-418-2:2025 [F(z)]
+dfz = sqrt(deltaFreq0^2 + (c*bandCentreFreqs).^2);  % Section 5.1.4.1 Equation 10 ECMA-418-2:2025 [deltaf(z)]
 
-% Block and hop sizes Section 6.2.2 Table 4 ECMA-418-2:2024
+% Block and hop sizes Section 6.2.2 Table 4 ECMA-418-2:2025
 overlap = 0.75;  % block overlap proportion
 % block sizes [s_b(z)]
 blockSize = [8192*ones(1, 3), 4096*ones(1, 13), 2048*ones(1, 9), 1024*ones(1, 28)];
@@ -209,23 +209,23 @@ blockSize = [8192*ones(1, 3), 4096*ones(1, 13), 2048*ones(1, 9), 1024*ones(1, 28
 hopSize = (1 - overlap)*blockSize;
 
 % Output sample rate based on hop sizes - Resampling to common time basis
-% Section 6.2.6 ECMA-418-2:2024 [r_sd]
+% Section 6.2.6 ECMA-418-2:2025 [r_sd]
 sampleRate1875 = sampleRate48k/min(hopSize);
 
 % Number of bands that need averaging. Section 6.2.3 Table 5
-% ECMA-418-2:2024 [NB]
+% ECMA-418-2:2025 [NB]
 NBandsAvg = [0, 1, 2*ones(1,14), ones(1,9), zeros(1,28);...
              1, 1, 2*ones(1,14), ones(1,9), zeros(1,28)];
 
 % Critical band interpolation factors from Section 6.2.6 Table 6
-% ECMA-418-2:2024 [i]
+% ECMA-418-2:2025 [i]
 i_interp = blockSize/min(blockSize);
 
-% Noise reduction constants from Section 6.2.7 Table 7 ECMA-418-2:2024
+% Noise reduction constants from Section 6.2.7 Table 7 ECMA-418-2:2025
 alpha = 20;
 beta = 0.07;
 
-% Sigmoid function factor parameters Section 6.2.7 Table 8 ECMA-418-2:2024
+% Sigmoid function factor parameters Section 6.2.7 Table 8 ECMA-418-2:2025
 % [c(s_b(z))]
 csz_b = [18.21*ones(1, 3), 12.14*ones(1, 13), 417.54*ones(1, 9),...
          962.68*ones(1, 28)]; 
@@ -233,12 +233,12 @@ csz_b = [18.21*ones(1, 3), 12.14*ones(1, 13), 417.54*ones(1, 9),...
 dsz_b = [0.36*ones(1, 3), 0.36*ones(1, 13), 0.71*ones(1, 9),...
          0.69*ones(1, 28)]; 
 
-% Scaling factor constants from Section 6.2.8 Table 9 ECMA-418-2:2024
+% Scaling factor constants from Section 6.2.8 Table 9 ECMA-418-2:2025
 A = 35;
 B = 0.003;
 
-cal_T = 2.8758615;  % calibration factor in Section 6.2.8 Equation 51 ECMA-418-2:2024 [c_T]
-cal_Tx = 1/0.9999043734252;  % Adjustment to calibration factor (Footnote 22 ECMA-418-2:2024)
+cal_T = 2.8758615;  % calibration factor in Section 6.2.8 Equation 51 ECMA-418-2:2025 [c_T]
+cal_Tx = 1/0.9999043734252;  % Adjustment to calibration factor (Footnote 22 ECMA-418-2:2025)
 
 %% Signal processing
 
@@ -250,13 +250,13 @@ else  % don't resample
     p_re = p;
 end
 
-% Section 5.1.2 ECMA-418-2:2024 Fade in weighting and zero-padding
+% Section 5.1.2 ECMA-418-2:2025 Fade in weighting and zero-padding
 pn = shmPreProc(p_re, max(blockSize), max(hopSize));
 
 % Apply outer & middle ear filter
 % -------------------------------
 %
-% Section 5.1.3.2 ECMA-418-2:2024 Outer and middle/inner ear signal filtering
+% Section 5.1.3.2 ECMA-418-2:2025 Outer and middle/inner ear signal filtering
 pn_om = shmOutMidEarFilter(pn, soundField);
 
 n_steps = 115;  % approximate number of calculation steps
@@ -278,7 +278,7 @@ for chan = chansIn:-1:1
     end % end of if branch for waitBar
 
     % Filter equalised signal using 53 1/2-overlapping Bark filters
-    % according to Section 5.1.4.2 ECMA-418-2:2024
+    % according to Section 5.1.4.2 ECMA-418-2:2025
     pn_omz = shmAuditoryFiltBank(pn_om(:, chan));
 
     % Autocorrelation function analysis
@@ -309,25 +309,25 @@ for chan = chansIn:-1:1
 
         % Segmentation into blocks
         % ------------------------
-        % Section 5.1.5 ECMA-418-2:2024
+        % Section 5.1.5 ECMA-418-2:2025
         i_start = blockSizeDupe(1) - blockSizeDupe(zBand) + 1;
         [pn_lz, ~] = shmSignalSegment(pn_omzDupe(:, zBand), 1,...
                                       blockSizeDupe(zBand), overlap, i_start);
  
         % Transformation into Loudness
         % ----------------------------
-        % Sections 5.1.6 to 5.1.9 ECMA-418-2:2024 [N'_basis(z)]
+        % Sections 5.1.6 to 5.1.9 ECMA-418-2:2025 [N'_basis(z)]
         [pn_rlz, bandBasisLoudness, ~]...
             = shmBasisLoudness(pn_lz, bandCentreFreqsDupe(zBand));
         basisLoudnessArray{zBand} = bandBasisLoudness;
 
         % Apply ACF
         % ACF implementation using DFT
-        % Section 6.2.2 Equations 27 & 28 ECMA-418-2:2024
+        % Section 6.2.2 Equations 27 & 28 ECMA-418-2:2025
         % [phi_unscaled,l,z(m)]
         unscaledACF = ifft(abs(fft(pn_rlz, 2*blockSizeDupe(zBand), 1)).^2,...
                            2*blockSizeDupe(zBand), 1);
-        % Section 6.2.2 Equation 29 ECMA-418-2:2024 [phi_l,z(m)]
+        % Section 6.2.2 Equation 29 ECMA-418-2:2025 [phi_l,z(m)]
         denom = sqrt(cumsum(pn_rlz.^2, 1, 'reverse').*flipud(cumsum(pn_rlz.^2, 1)))...
                 + 1e-12;
 
@@ -337,7 +337,7 @@ for chan = chansIn:-1:1
         unbiasedNormACF = unscaledACF(1:blockSizeDupe(zBand), :)./denom;
         unbiasedNormACF((0.75*blockSizeDupe(zBand) + 1):blockSizeDupe(zBand), :) = 0;
 
-        % Section 6.2.2 Equation 30 ECMA-418-2:2024 [phi_z'(m)
+        % Section 6.2.2 Equation 30 ECMA-418-2:2025 [phi_z'(m)
         unbiasedNormACFDupe{zBand} = basisLoudnessArray{zBand}.*unbiasedNormACF;
 
     end
@@ -346,7 +346,7 @@ for chan = chansIn:-1:1
         i_step = i_step + 62;  % increment calculation step for waitbar
     end
 
-    % Average the ACF over nB bands - Section 6.2.3 ECMA-418-2:2024        
+    % Average the ACF over nB bands - Section 6.2.3 ECMA-418-2:2025        
     for zBand = 53:-1:1  % Loop through 53 critical band filtered signals
         if waitBar
             waitbar(((54 - zBand) + i_step)/n_steps, w,...
@@ -366,14 +366,14 @@ for chan = chansIn:-1:1
                                                 'EndPoints', 'discard');
         end
         
-        % Application of ACF lag window Section 6.2.4 ECMA-418-2:2024
-        tauz_start = max(0.5/dfz(zBand), 2e-3);  % Equation 31 ECMA-418-2:2024 [tau_start(z)]
-        tauz_end = max(4/dfz(zBand), tauz_start + 1e-3);  % Equation 32 ECMA-418-2:2024 [tau_end(z)]
-        % Equations 33 & 34 ECMA-418-2:2024
+        % Application of ACF lag window Section 6.2.4 ECMA-418-2:2025
+        tauz_start = max(0.5/dfz(zBand), 2e-3);  % Equation 31 ECMA-418-2:2025 [tau_start(z)]
+        tauz_end = max(4/dfz(zBand), tauz_start + 1e-3);  % Equation 32 ECMA-418-2:2025 [tau_end(z)]
+        % Equations 33 & 34 ECMA-418-2:2025
         mz_start = ceil(tauz_start*sampleRate48k);  % Starting lag window index [m_start(z)]
         mz_end = floor(tauz_end*sampleRate48k);  % Ending lag window index [m_end(z)]
         M = mz_end - mz_start + 1;
-        % Equation 35 ECMA-418-2:2024
+        % Equation 35 ECMA-418-2:2025
         % lag-windowed, detrended ACF [phi'_z,tau(m)]
         lagWindowACF = zeros(size(meanScaledACF));
         lagWindowACF(mz_start:mz_end, :) = meanScaledACF(mz_start:mz_end, :)...
@@ -381,28 +381,28 @@ for chan = chansIn:-1:1
 
         % Estimation of tonal loudness
         % ----------------------------
-        % Section 6.2.5 Equation 36 ECMA-418-2:2024
+        % Section 6.2.5 Equation 36 ECMA-418-2:2025
         % ACF spectrum in the lag window [Phi'_z,tau(k)]
         magFFTlagWindowACF = abs(fft(lagWindowACF, 2*max(blockSize), 1));
         magFFTlagWindowACF(isnan(magFFTlagWindowACF)) = 0;
 
-        % Section 6.2.5 Equation 37 ECMA-418-2:2024 [Nhat'_tonal(z)]
+        % Section 6.2.5 Equation 37 ECMA-418-2:2025 [Nhat'_tonal(z)]
         % first estimation of specific loudness of tonal component in critical band
         bandTonalLoudness = meanScaledACF(1, :);
         mask = 2*max(magFFTlagWindowACF, [], 1)/(M/2) <= meanScaledACF(1, :);
         bandTonalLoudness(mask) = 2*max(magFFTlagWindowACF(:, mask), [], 1)/(M/2);
 
-        % Section 6.2.5 Equation 38 & 39 ECMA-418-2:2024
+        % Section 6.2.5 Equation 38 & 39 ECMA-418-2:2025
         % [k_max(z)]
         [~, kz_max] = max(magFFTlagWindowACF, [], 1);
         % frequency of maximum tonal component in critical band [f_ton(z)]
         bandTonalFreqs = (kz_max - 1)*(sampleRate48k/(2*max(blockSize)));
 
-        % Section 6.2.7 Equation 41 ECMA-418-2:2024 [N'_signal(l,z)]
+        % Section 6.2.7 Equation 41 ECMA-418-2:2025 [N'_signal(l,z)]
         % specific loudness of complete band-pass signal in critical band
         bandLoudness = meanScaledACF(1, :);
         
-        % Resampling to common time basis Section 6.2.6 ECMA-418-2:2024
+        % Resampling to common time basis Section 6.2.6 ECMA-418-2:2025
         if i_interp(zBand) > 1
             % Note: use of interpolation function avoids rippling caused by
             % resample function, which otherwise affects specific loudness 
@@ -417,39 +417,39 @@ for chan = chansIn:-1:1
 
         end  % end of if branch for interpolation
 
-        % Remove end zero-padded samples Section 6.2.6 ECMA-418-2:2024
-        l_end = ceil(size(p_re, 1)/sampleRate48k*sampleRate1875) + 1;  % Equation 40 ECMA-418-2:2024
+        % Remove end zero-padded samples Section 6.2.6 ECMA-418-2:2025
+        l_end = ceil(size(p_re, 1)/sampleRate48k*sampleRate1875) + 1;  % Equation 40 ECMA-418-2:2025
         bandTonalLoudness = bandTonalLoudness(1:l_end);
         bandLoudness = bandLoudness(1:l_end);
         bandTonalFreqs = bandTonalFreqs(1:l_end);
 
         % Noise reduction Section 6.2.7 ECMA-418-2:2020
         % ---------------------------------------------
-        % Equation 42 ECMA-418-2:2024 signal-noise-ratio first approximation
+        % Equation 42 ECMA-418-2:2025 signal-noise-ratio first approximation
         % (ratio of tonal component loudness to non-tonal component loudness in critical band)
         % [SNRhat(l,z)]
         SNRlz1 = bandTonalLoudness./((bandLoudness - bandTonalLoudness) + 1e-12);
 
-        % Equation 43 ECMA-418-2:2024 low pass filtered specific loudness
+        % Equation 43 ECMA-418-2:2025 low pass filtered specific loudness
         % of non-tonal component in critical band [Ntilde'_tonal(l,z)]
         bandTonalLoudness = shmNoiseRedLowPass(bandTonalLoudness, sampleRate1875);
 
-        % Equation 44 ECMA-418-2:2024 lowpass filtered SNR (improved estimation)
+        % Equation 44 ECMA-418-2:2025 lowpass filtered SNR (improved estimation)
         % [SNRtilde(l,z)]
         SNRlz = shmNoiseRedLowPass(SNRlz1, sampleRate1875);
 
-        % Equation 46 ECMA-418-2:2024 [g(z)]
+        % Equation 46 ECMA-418-2:2025 [g(z)]
         gz = csz_b(zBand)/(bandCentreFreqs(zBand)^dsz_b(zBand));
 
-        % Equation 45 ECMA-418-2:2024 [nr(l,z)]
+        % Equation 45 ECMA-418-2:2025 [nr(l,z)]
         crit = exp(-alpha*((SNRlz/gz) - beta));
         nrlz = 1 - crit;  % sigmoidal weighting function
         nrlz(crit >= 1) = 0;
 
-        % Equation 47 ECMA-418-2:2024 [N'_tonal(l,z)]
+        % Equation 47 ECMA-418-2:2025 [N'_tonal(l,z)]
         bandTonalLoudness = nrlz.*bandTonalLoudness;
 
-        % Section 6.2.8 Equation 48 ECMA-418-2:2024 [N'_noise(l,z)]
+        % Section 6.2.8 Equation 48 ECMA-418-2:2025 [N'_noise(l,z)]
         bandNoiseLoudness = shmNoiseRedLowPass(bandLoudness, sampleRate1875) - bandTonalLoudness;  % specific loudness of non-tonal component in critical band
     
         % Store critical band results
@@ -473,24 +473,24 @@ for chan = chansIn:-1:1
 
     % Calculation of specific tonality
     % --------------------------------
-    % Section 6.2.8 Equation 49 ECMA-418-2:2024 [SNR(l)]
+    % Section 6.2.8 Equation 49 ECMA-418-2:2025 [SNR(l)]
     overallSNR = max(specTonalLoudness, [], 2)./(1e-12 + sum(specNoiseLoudness, 2));  % loudness signal-noise-ratio
     
-    % Section 6.2.8 Equation 50 ECMA-418-2:2024 [q(l)]
+    % Section 6.2.8 Equation 50 ECMA-418-2:2025 [q(l)]
     crit = exp(-A*(overallSNR - B));
     ql = 1 - crit;  % sigmoidal scaling factor
     ql(crit >= 1) = 0;
     
-    % Section 6.2.8 Equation 51 ECMA-418-2:2024 [T'(l,z)]
+    % Section 6.2.8 Equation 51 ECMA-418-2:2025 [T'(l,z)]
     specTonality = cal_T*cal_Tx*ql.*specTonalLoudness;  % time-dependent specific tonality
     
     % Calculation of time-averaged specific tonality Section 6.2.9
-    % ECMA-418-2:2024 [T'(z)]
+    % ECMA-418-2:2025 [T'(z)]
     for zBand = 53:-1:1
         mask = specTonality(:, zBand, chan) > 0.02;  % criterion Section 6.2.9 point 2
         mask(1:(58 - 1)) = 0;  % criterion Section 6.2.9 point 1
 
-        % Section 6.2.9 Equation 53 ECMA-418-2:2024
+        % Section 6.2.9 Equation 53 ECMA-418-2:2025
         specTonalityAvg(1, zBand, chan)...
             = sum(specTonality(mask, zBand, chan), 1)./(nnz(mask) + 1e-12);
         specTonalityAvgFreqs(1, zBand, chan)...
@@ -502,11 +502,11 @@ for chan = chansIn:-1:1
     % Further update can add the user input frequency range to determine
     % total tonality - not yet incorporated
 
-    % Section 6.2.8 Equation 52 ECMA-418-2:2024
+    % Section 6.2.8 Equation 52 ECMA-418-2:2025
     % time (s) corresponding with results output [t]
     timeOut = (0:(size(specTonality, 1) - 1))/sampleRate1875;
 
-    % Section 6.2.10 Equation 61 ECMA-418-2:2024
+    % Section 6.2.10 Equation 61 ECMA-418-2:2025
     % Time-dependent total tonality [T(l)]
     [tonalityTDep(:, chan), zmax] = max(specTonality(:, :, chan),...
                                            [], 2);
@@ -514,12 +514,12 @@ for chan = chansIn:-1:1
         tonalityTDepFreqs(ll, chan) = specTonalityFreqs(ll, zmax(ll), chan);
     end
     
-    % Calculation of representative values Section 6.2.11 ECMA-418-2:2024
+    % Calculation of representative values Section 6.2.11 ECMA-418-2:2025
     % Time-averaged total tonality
     mask = tonalityTDep(:, chan) > 0.02;  % criterion Section 6.2.9 point 2
     mask(1:(58 - 1)) = 0;    % criterion Section 6.2.9 point 1
 
-    % Section 6.2.11 Equation 63 ECMA-418-2:2024
+    % Section 6.2.11 Equation 63 ECMA-418-2:2025
     % Time-averaged total tonality [T]
     tonalityAvg(chan) = sum(tonalityTDep(mask, chan))/(nnz(mask) + eps);
 


### PR DESCRIPTION
Updated version to 2025, including the slight tweak introduced to roughness peak-finding section 7.1.5.1 to address occasional appearance of artefacts in results.